### PR TITLE
fix: Correctly parse absolute paths in OpenAPI servers

### DIFF
--- a/src/oas3/Servers.ts
+++ b/src/oas3/Servers.ts
@@ -4,7 +4,7 @@ import { compileTemplatePath, PathParserFunction } from './Paths/PathResolver';
 import { ParametersMap } from '../types';
 
 const FULL_URL_RE = /^(.*?):\/\/([^/]*?)\/(.*)$/; // e.g. https://foo.bar/v1
-const ABSOLUTE_URL_RE = /^\/(.*)$/; // e.g. /v1
+const ABSOLUTE_URL_RE = /^(\/.*)$/; // e.g. /v1
 
 export interface ResolvedServer {
     oaServer: oas3.ServerObject;


### PR DESCRIPTION
Fix https://github.com/exegesis-js/exegesis/issues/24