### PR TITLE
fix: pathname from full url servers

### DIFF
--- a/src/oas3/Servers.ts
+++ b/src/oas3/Servers.ts
@@ -47,7 +47,7 @@ function generateServerParser(oaServer: oas3.ServerObject) : ServerParser {
             if(hostMatch && pathMatch) {
                 return {
                     oaServer,
-                    pathnameRest: pathname.slice(pathMatch.matched.length-1),
+                    pathnameRest: pathname.slice(pathMatch.matched.length),
                     serverParams: Object.assign({}, hostMatch.rawPathParams, pathMatch.rawPathParams),
                 };
             } else {

--- a/test/oas3/ServersTest.ts
+++ b/test/oas3/ServersTest.ts
@@ -1,0 +1,31 @@
+import { expect } from 'chai';
+
+import Servers from '../../lib/oas3/Servers';
+
+describe('oas3 Servers', () => {
+
+    describe('generateServerParser', () => {
+
+        it('removes server absolute url from path', () => {
+            const oas3Server = {
+                url: '/api',
+            };
+            const servers = new Servers([oas3Server]);
+            const parser = servers['_servers'][0];
+            const result = parser('host', '/api/v1/foo');
+            expect(result.pathnameRest).to.eql('/v1/foo');
+        });
+
+        it('removes server full url from path', () => {
+            const oas3Server = {
+                url: 'https://localhost:3030/api',
+            };
+            const servers = new Servers([oas3Server]);
+            const parser = servers['_servers'][0];
+            const result = parser('localhost:3030', '/api/v1/foo');
+            expect(result.pathnameRest).to.eql('/v1/foo');
+        });
+
+    });
+
+});


### PR DESCRIPTION
When servers urls were full urls, the path name extracted was off by one character. See the unit tests added.