### PR TITLE
fix: stringify json body

### DIFF
--- a/src/core/ExegesisResponseImpl.ts
+++ b/src/core/ExegesisResponseImpl.ts
@@ -38,7 +38,7 @@ export default class ExegesisResponseImpl implements types.ExegesisResponse {
 
     json(json: any) {
         this.set('content-type', 'application/json')
-            .setBody(json);
+            .setBody(JSON.stringify(json));
         return this;
     }
 

--- a/test/core/ExegesisResponseImplTest.ts
+++ b/test/core/ExegesisResponseImplTest.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+
+import ExegesisResponseImpl from '../../lib/core/ExegesisResponseImpl';
+
+describe('ExegesisResponseImpl', () => {
+
+    describe('json', () => {
+
+        it('uses the object toJSON', () => {
+            class StringWrapper {
+                private readonly _content: string;
+
+                constructor(content: string) {
+                    this._content = content;
+                }
+
+                public toJSON() {
+                    return this._content;
+                }
+            }
+
+            const data = {
+                content: new StringWrapper('foo'),
+            };
+
+            const res = new ExegesisResponseImpl({} as any);
+            res.json(data);
+            expect(res.body).to.eql(JSON.stringify({ content: 'foo' }));
+        });
+
+    });
+
+});


### PR DESCRIPTION
Call `JSON.stringify` on the body when setting it with the `res.json()` function, which ends up calling `toJSON()` on objects if it is defined. For example, this is useful with [MongoDB BSON ObjectIds](https://github.com/mongodb/js-bson/blob/master/lib/objectid.js#L214)