### PR TITLE
fix: 🐛 Add support for OpenAPI nullable field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -545,20 +545,20 @@
       }
     },
     "ajv": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.0.tgz",
-      "integrity": "sha512-VDUX1oSajablmiyFyED9L1DFndg0P9h7p1F+NO8FkIzei6EPrR6Zu1n18rd5P8PqaSRd/FrWv3G1TVBqpM83gA==",
+      "version": "6.6.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
+      "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
       "requires": {
         "fast-deep-equal": "^2.0.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0",
-        "uri-js": "^4.2.1"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
       },
       "dependencies": {
         "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         }
       }
     },
@@ -5529,9 +5529,9 @@
       }
     },
     "punycode": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-      "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "1.0.0",
@@ -6811,9 +6811,9 @@
       }
     },
     "uri-js": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.1.tgz",
-      "integrity": "sha512-jpKCA3HjsBfSDOEgxRDAxQCNyHfCPSbq57PqCkd3gAyBuPb3IWxw54EHncqESznIdqSetHfw3D7ylThu2Kcc9A==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "typescript": "^2.8.3"
   },
   "dependencies": {
-    "ajv": "^6.5.0",
+    "ajv": "^6.6.1",
     "body-parser": "^1.18.2",
     "content-type": "^1.0.4",
     "deep-freeze": "0.0.1",

--- a/src/oas3/Schema/validators.ts
+++ b/src/oas3/Schema/validators.ts
@@ -6,7 +6,6 @@ import * as jsonSchema from '../../utils/jsonSchema';
 import Oas3CompileContext from '../Oas3CompileContext';
 
 // TODO tests
-// * nullable
 // * readOnly
 // * readOnly with additionalProperties and value supplied
 // * readOnly not supplied but required
@@ -195,7 +194,8 @@ function generateValidator(
         useDefaults: true,
         coerceTypes: allowTypeCoercion ? 'array' : false,
         removeAdditional: allowTypeCoercion ? 'failing' : false,
-        jsonPointers: true
+        jsonPointers: true,
+        nullable: true,
     });
     addCustomFormats(ajv, customFormats);
     const validate = ajv.compile(schema);

--- a/test/oas3/Schema/validatorsTest.ts
+++ b/test/oas3/Schema/validatorsTest.ts
@@ -53,6 +53,16 @@ const openApiDoc : oas3.OpenAPIObject = Object.assign(
                         }
                     }
                 },
+                aNullableObject: {
+                    type: 'object',
+                    required: ['a'],
+                    nullable: true,
+                    properties: {
+                        a: {
+                            type: 'string',
+                        }
+                    }
+                },
                 withDefault: {
                     type: 'object',
                     properties: {
@@ -242,6 +252,15 @@ describe('schema validators', function() {
         const validator = validators.generateRequestValidator(context, QUERY_PARAM_LOCATION, false);
 
         expect(validator(7).errors).to.eql(null);
+        expect(validator(undefined).errors).to.eql(null);
+    });
+
+    it('should not error for a missing object if nullable', function() {
+        const context = makeContext(openApiDoc, '#/components/schemas/aNullableObject');
+
+        const validator = validators.generateRequestValidator(context, QUERY_PARAM_LOCATION, false);
+
+        expect(validator(null).errors).to.eql(null);
         expect(validator(undefined).errors).to.eql(null);
     });
 


### PR DESCRIPTION
As a result of the divergence of the OpenAPI spec and JSON Schema the
underlying Ajv libary needed upgraded to support for the nullable field.

Issues: Fixes #51