### PR TITLE
Added 'in bytes' to the defaultMaxBodySize description

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -119,7 +119,7 @@ still be used for parsing request bodies.
 ## defaultMaxBodySize
 
 If a `MimeTypeParser` provided in `mimeTypeParsers` does not support
-`parseReq()`, this defines the maximum size of a body that will be parsed.
+`parseReq()`, this defines the maximum size (in bytes) of a body that will be parsed.
 Bodies longer than this will result in a "413 - Payload Too Large" error.
 Built in body parsers will also respect this option.
 


### PR DESCRIPTION
Looked through the code and found that the maxBodySize is getting passed to https://github.com/expressjs/body-parser#limit which states that if the 'limit' is a number, it expects the value to be in bytes.