### PR TITLE
Fix typo

### DIFF
--- a/docs/Tutorial.md
+++ b/docs/Tutorial.md
@@ -181,7 +181,7 @@ async function createServer() {
         allowMissingControllers: false
     };
 
-    // This creates an exgesis middleware, which can be used with express,
+    // This creates an exegesis middleware, which can be used with express,
     // connect, or even just by itself.
     const exegesisMiddleware = await exegesisExpress.middleware(
         path.resolve(__dirname, './openapi.yaml'),

--- a/samples/javascript-example/index.js
+++ b/samples/javascript-example/index.js
@@ -10,7 +10,7 @@ async function createServer() {
         allowMissingControllers: false
     };
 
-    // This creates an exgesis middleware, which can be used with express,
+    // This creates an exegesis middleware, which can be used with express,
     // connect, or even just by itself.
     const exegesisMiddleware = await exegesisExpress.middleware(
         path.resolve(__dirname, './openapi.yaml'),

--- a/samples/typescript-example/server.ts
+++ b/samples/typescript-example/server.ts
@@ -1,4 +1,4 @@
-//Import librarys used 
+//Import librarys used
 import * as express from 'express';
 import * as exegesisExpress from 'exegesis-express';
 import * as path from 'path';
@@ -18,7 +18,7 @@ async function createServer() {
         controllersPattern: "**/*.@(ts|js)"
     };
 
-    // This creates an exgesis middleware, which can be used with express,
+    // This creates an exegesis middleware, which can be used with express,
     // connect, or even just by itself.
     const exegesisMiddleware = await exegesisExpress.middleware(
         path.resolve(__dirname, './openapi.yaml'),
@@ -44,10 +44,10 @@ async function createServer() {
 
     /**
      * If you want to run a HTTPS server instead you must:
-     * + Get a SSL Cert and Key to use 
+     * + Get a SSL Cert and Key to use
      * + Change the server type from http to https as shown below
      *
-     
+
     const httpsOptions = {
         key: fs.readFileSync('./config/key.pem'),
         cert: fs.readFileSync('./config/cert.pem')

--- a/src/oas3/Oas3CompileContext.ts
+++ b/src/oas3/Oas3CompileContext.ts
@@ -4,7 +4,7 @@ import * as oas3 from 'openapi3-ts';
 import * as jsonPtr from 'json-ptr';
 import { resolveRef } from '../utils/json-schema-resolve-ref';
 
-import { ExgesisCompiledOptions } from '../options';
+import { ExegesisCompiledOptions } from '../options';
 
 /**
  * A path to an object within a JSON document.
@@ -20,7 +20,7 @@ export default class Oas3CompileContext {
     readonly path: JsonPath;
     readonly jsonPointer: string;
     readonly openApiDoc: oas3.OpenAPIObject;
-    readonly options: ExgesisCompiledOptions;
+    readonly options: ExegesisCompiledOptions;
 
     /**
      * Create a new Oas3CompileContext.
@@ -29,9 +29,9 @@ export default class Oas3CompileContext {
      * @param path - The path to the object represented by this context.
      * @param options - Options.
      */
-    constructor(openApiDoc: oas3.OpenAPIObject, path: JsonPath, options: ExgesisCompiledOptions)
+    constructor(openApiDoc: oas3.OpenAPIObject, path: JsonPath, options: ExegesisCompiledOptions)
     constructor(parent: Oas3CompileContext, relativePath: JsonPath)
-    constructor(a: any, path: JsonPath, options?: ExgesisCompiledOptions) {
+    constructor(a: any, path: JsonPath, options?: ExegesisCompiledOptions) {
         if(a instanceof Oas3CompileContext) {
             // TODO: Could make this WAY more efficient with Object.create().
             const parent = a;

--- a/src/oas3/OpenApi.ts
+++ b/src/oas3/OpenApi.ts
@@ -3,7 +3,7 @@ import * as semver from 'semver';
 import * as http from 'http';
 import * as oas3 from 'openapi3-ts';
 
-import { ExgesisCompiledOptions } from '../options';
+import { ExegesisCompiledOptions } from '../options';
 import { ApiInterface, ResolvedPath, ParsedParameterValidator, ResolvedOperation } from '../types/internal';
 import { ParametersMap, OAS3ApiInfo, ExegesisContext, AuthenticationSuccess, ExegesisResponse } from '../types';
 import Paths from './Paths';
@@ -15,7 +15,7 @@ import { HttpBadRequestError } from '../errors';
 
 export default class OpenApi implements ApiInterface<OAS3ApiInfo> {
     readonly openApiDoc: oas3.OpenAPIObject;
-    private readonly _options: ExgesisCompiledOptions;
+    private readonly _options: ExegesisCompiledOptions;
     private _servers?: Servers;
     private _paths : Paths;
 
@@ -27,7 +27,7 @@ export default class OpenApi implements ApiInterface<OAS3ApiInfo> {
      */
     constructor(
         openApiDoc: oas3.OpenAPIObject,
-        options: ExgesisCompiledOptions
+        options: ExegesisCompiledOptions
     ) {
         if(!openApiDoc.openapi) {
             throw new Error("OpenAPI definition is missing 'openapi' field");

--- a/src/oas3/index.ts
+++ b/src/oas3/index.ts
@@ -1,7 +1,9 @@
 import oas3 from 'openapi3-ts';
 
 import OpenApi from './OpenApi';
-import { ExgesisCompiledOptions } from '../options';
+import { ExegesisCompiledOptions } from '../options';
+
+export { OpenApi };
 
 /**
  * Reads an OpenAPI document from a YAML or JSON file.
@@ -11,7 +13,7 @@ import { ExgesisCompiledOptions } from '../options';
  */
 export async function compile(
     openApiDoc: oas3.OpenAPIObject,
-    options: ExgesisCompiledOptions
+    options: ExegesisCompiledOptions
 ): Promise<OpenApi> {
     return new OpenApi(openApiDoc, options);
 }

--- a/src/options.ts
+++ b/src/options.ts
@@ -18,7 +18,7 @@ import {
 } from './types';
 import {handleErrorFunction} from "./types/options";
 
-export interface ExgesisCompiledOptions {
+export interface ExegesisCompiledOptions {
     customFormats: CustomFormats;
     controllers: Controllers;
     authenticators: Authenticators;
@@ -71,7 +71,7 @@ const defaultValidators : CustomFormats = {
     base64: () => true
 };
 
-export function compileOptions(options: ExegesisOptions = {}) : ExgesisCompiledOptions {
+export function compileOptions(options: ExegesisOptions = {}) : ExegesisCompiledOptions {
     const maxBodySize = options.defaultMaxBodySize || 100000;
 
     const mimeTypeParsers = Object.assign(

--- a/test/fixtures/index.ts
+++ b/test/fixtures/index.ts
@@ -3,7 +3,7 @@ import * as oas3 from 'openapi3-ts';
 import Oas3CompileContext from '../../src/oas3/Oas3CompileContext';
 import * as options from '../../src/options';
 
-export const defaultCompiledOptions: options.ExgesisCompiledOptions = options.compileOptions();
+export const defaultCompiledOptions: options.ExegesisCompiledOptions = options.compileOptions();
 
 export function makeOpenApiDoc(): oas3.OpenAPIObject {
     return {
@@ -19,7 +19,7 @@ export function makeOpenApiDoc(): oas3.OpenAPIObject {
 export function makeContext(
     openApiDoc: oas3.OpenAPIObject,
     jsonPointer: string,
-    options?: Partial<options.ExgesisCompiledOptions>
+    options?: Partial<options.ExegesisCompiledOptions>
 ) {
     return new Oas3CompileContext(
         openApiDoc,


### PR DESCRIPTION
There were a few instances of `exgesis`, fixed them. `ExegesisCompiledOptions` is not an exported type so this shouldn't be a breaking change.