### PR TITLE
feat: make request available to custom error handler

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -162,7 +162,7 @@ By default, ExegesisRunner will turn `exegesis.HttpError`s (such as errors
 generated from `context.makeError()`, `exegesis.ValidationError`s, or any error
 with a `.status` into JSON replies with appropriate error messages.  If you want
 to handle these errors yourself, set this value to false, alternatively set the value
-to a `function(err)` function that handles the error returning a `HttpResult` object.
+to a `function(err, req)` function that handles the error returning a `HttpResult` object.
 See [customErrorHandler](../test/integration/customErrorHandler.ts) for an example.
 
 Note that all `HttpError`s will have a `.status` property with a suggested

--- a/src/core/exegesisRunner.ts
+++ b/src/core/exegesisRunner.ts
@@ -219,7 +219,7 @@ export default async function generateExegesisRunner<T>(
         } catch (err) {
             if(options.autoHandleHttpErrors) {
                 if (options.autoHandleHttpErrors instanceof Function) {
-                    return options.autoHandleHttpErrors(err);
+                    return options.autoHandleHttpErrors(err, req);
                 }
                 return handleError(err);
             } else {

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,13 +1,14 @@
 import { StringParser, BodyParser } from './bodyParser';
 import { Controllers, Authenticators, ExegesisPlugin } from './core';
 import { ResponseValidationCallback } from './validation';
+import * as http from "http";
 
 /**
  * A function which validates custom formats.
  */
 export type CustomFormatChecker =  RegExp | ((value: string) => boolean);
 
-export type handleErrorFunction = (err: Error) => any;
+export type handleErrorFunction = (err: Error, req: http.IncomingMessage) => any;
 
 export interface StringCustomFormatChecker {
     type: 'string';


### PR DESCRIPTION
Some error handlers may wish to use the incoming request to format error responses