### PR TITLE
Ignore Content-Type header when there is no request body

### DIFF
--- a/src/bodyParsers/BodyParserWrapper.ts
+++ b/src/bodyParsers/BodyParserWrapper.ts
@@ -2,7 +2,7 @@ import http from 'http';
 import contentType from 'content-type';
 import getRawBody from 'raw-body';
 
-import httpHasBody from '../utils/httpHasBody';
+import { httpHasBody } from '../utils/httpUtils';
 import { MimeTypeParser, StringParser, HttpIncomingMessage, Callback } from '../types';
 
 export default class BodyParserWrapper implements MimeTypeParser {

--- a/src/oas3/OpenApi.ts
+++ b/src/oas3/OpenApi.ts
@@ -21,6 +21,7 @@ import Oas3CompileContext from './Oas3CompileContext';
 import { EXEGESIS_CONTROLLER, EXEGESIS_OPERATION_ID } from './extensions';
 import RequestMediaType from './RequestMediaType';
 import { HttpBadRequestError } from '../errors';
+import { httpHasBody, requestMayHaveBody } from '../utils/httpUtils';
 
 export default class OpenApi implements ApiInterface<OAS3ApiInfo> {
     readonly openApiDoc: oas3.OpenAPIObject;
@@ -95,7 +96,7 @@ export default class OpenApi implements ApiInterface<OAS3ApiInfo> {
 
                 if (operation && contentType) {
                     mediaType = operation.getRequestMediaType(contentType);
-                    if (!mediaType) {
+                    if (!mediaType && (httpHasBody(headers) || requestMayHaveBody(method))) {
                         throw new HttpBadRequestError(`Invalid content-type: ${contentType}`);
                     }
                 } else if (

--- a/src/utils/httpHasBody.ts
+++ b/src/utils/httpHasBody.ts
@@ -1,7 +1,0 @@
-export default function httpHasBody(headers: { [header: string]: any }): boolean {
-    const contentLength = headers['content-length'];
-    return (
-        !!headers['transfer-encoding'] ||
-        (contentLength && contentLength !== '0' && contentLength !== 0)
-    );
-}

--- a/src/utils/httpUtils.ts
+++ b/src/utils/httpUtils.ts
@@ -1,0 +1,14 @@
+export function httpHasBody(headers: { [header: string]: any }): boolean {
+    const contentLength = headers['content-length'];
+    return (
+        !!headers['transfer-encoding'] ||
+        (contentLength && contentLength !== '0' && contentLength !== 0)
+    );
+}
+
+// `delete` might have a body. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE
+const HTTP_METHODS_WITHOUT_BODY = ['get', 'head', 'trace', 'options'];
+
+export function requestMayHaveBody(method: string) {
+    return HTTP_METHODS_WITHOUT_BODY.indexOf(method.toLowerCase()) === -1;
+}


### PR DESCRIPTION
Issue: #105

Some clients send a Content-Type header in GET and DELETE requests that don't send a payload. Although this doesn't make much sense, sometimes it's difficult to correct it. So to make things more convenient, ignore the Content-Type validation if the request has no body, and it's not required to have a body.

This behavior is enabled by default, so there is no feature flag. But I can add one if you think there should still be validation by default.