### PR TITLE
fix: Return the result in `JsonBodyParser.parseString`

### DIFF
--- a/src/bodyParsers/JsonBodyParser.ts
+++ b/src/bodyParsers/JsonBodyParser.ts
@@ -16,7 +16,7 @@ export default class JsonBodyParser implements MimeTypeParser {
     }
 
     parseString(value: string) {
-        JSON.parse(value);
+        return JSON.parse(value);
     }
 
     parseReq(req: http.IncomingMessage, res: http.ServerResponse, done: Callback<void>): void {


### PR DESCRIPTION
Noticed this while reading through the source code. 

It _might_ be possible to pass generics from `ExegesisOptions` down to type `StringParserFunction` but not sure if it's worth it :stuck_out_tongue: 