### PR TITLE
Incorrect syntax for securitySchemes example

### DIFF
--- a/docs/OAS3 Security.md
+++ b/docs/OAS3 Security.md
@@ -176,7 +176,8 @@ Here's an example of the securitySchemes section from an OpenAPI document:
 
 ```yaml
   securitySchemes:
-    basicAuth: A request with a username and password
+    basicAuth: 
+      description: A request with a username and password
       type: http
       scheme: basic
     oauth:


### PR DESCRIPTION
The text describing basicAuth should be on the following line with a description key