### PR TITLE
`delete` might have a body.

### DIFF
--- a/src/oas3/Operation.ts
+++ b/src/oas3/Operation.ts
@@ -26,7 +26,8 @@ import { EXEGESIS_CONTROLLER, EXEGESIS_OPERATION_ID } from './extensions';
 import Responses from './Responses';
 import SecuritySchemes from './SecuritySchemes';
 
-const METHODS_WITH_BODY = ['post', 'put', 'patch'];
+// `delete` might have a body. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE
+const METHODS_WITH_BODY = ['post', 'put', 'patch', 'delete'];
 
 function isAuthenticationFailure(result: any): result is AuthenticationFailure {
     return !!(result.type === 'invalid' || result.type === 'missing');


### PR DESCRIPTION
Route DELETE and exegesis

exegesis thinks that DELETE might have a body. And If it finds “content-type” it tries to validate the incoming body
```
## exegesis/lib/utils/httpUtils.js

// `delete` might have a body. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/DELETE
const HTTP_METHODS_WITHOUT_BODY = ['get', 'head', 'trace', 'options'];
function requestMayHaveBody(method) {
    return HTTP_METHODS_WITHOUT_BODY.indexOf(method.toLowerCase()) === -1;
}
```

But on the other hand, exegesis make body-validators only for methods like this(there is no DELETE method)

```
## exegesis/lib/oas3/Operation.js

const METHODS_WITH_BODY = ['post', 'put', 'patch'];    
const requestBody = oaOperation.requestBody && METHODS_WITH_BODY.includes(method)
            ? context.resolveRef(oaOperation.requestBody)
            : undefined;
```

Conclusion:  If someone sends any “content-type” with the method “DELETE” it always be an error even if you have a schema for this “content-type”