### PR TITLE
feat: Add lazyCompileValidationSchemas option

### DIFF
--- a/docs/Options.md
+++ b/docs/Options.md
@@ -233,3 +233,9 @@ If set, then when encountering a validation error Exegesis will return
 all errors found in the document instead of just the first error. This
 causes Exegesis to spend more time on requests with errors in them, so
 for performance reasons this is disabled by default.
+
+## lazyCompileValidationSchemas
+
+Response and request schemas are compiled by ajv to make validation faster. However compilation is slow
+and can cause compilation of API to take long time. Enabling this will cause validation schemas
+compilation to be executed when the validator is needed.

--- a/src/options.ts
+++ b/src/options.ts
@@ -37,6 +37,7 @@ export interface ExegesisCompiledOptions {
     allErrors: boolean;
     treatReturnedJsonAsPure: boolean;
     strictValidation: boolean;
+    lazyCompileValidationSchemas: boolean;
 }
 
 // See the OAS 3.0 specification for full details about supported formats:
@@ -134,5 +135,6 @@ export function compileOptions(options: ExegesisOptions = {}): ExegesisCompiledO
         allErrors: options.allErrors || false,
         treatReturnedJsonAsPure: options.treatReturnedJsonAsPure || false,
         strictValidation: options.strictValidation ?? false,
+        lazyCompileValidationSchemas: options.lazyCompileValidationSchemas ?? false,
     };
 }

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -164,4 +164,11 @@ export interface ExegesisOptions {
      * If true, then this will put ajv into "strict mode" (see https://ajv.js.org/strict-mode.html).
      */
     strictValidation?: boolean;
+
+    /**
+     * Response and request schemas are compiled by ajv to make validation faster. However compilation is slow
+     * and can cause compilation of API to take long time. Enabling this will cause validation schemas
+     * compilation to be executed when the validator is needed.
+     */
+    lazyCompileValidationSchemas?: boolean;
 }


### PR DESCRIPTION
Added lazyCompileValidationSchemas option which enables to compile validation schemas when actually needing them. This may speed up application startup dramatically depending on the API size.

I implemented this by wrapping the validate function in a getter. I could not just replace the validate function because ajv does some weird stuff with having properties on a function. I am not confident replacing that with anything, so wrapping it in getter seemed like only reasonable option.

The option is disabled by default, as to not change behavior for existing users, so that it can be released as minor or even patch version.