### PR TITLE
feat: qs -> neoqs

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,10 +84,10 @@
         "json-ptr": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
         "lodash": "^4.17.11",
+        "neoqs": "^6.12.4",
         "openapi3-ts": "^3.1.1",
         "promise-breaker": "^6.0.0",
         "pump": "^3.0.0",
-        "qs": "^6.6.0",
         "raw-body": "^2.3.3",
         "semver": "^7.0.0"
     },

--- a/src/oas3/parameterParsers/index.ts
+++ b/src/oas3/parameterParsers/index.ts
@@ -1,6 +1,6 @@
 import ld from 'lodash';
 import querystring from 'querystring';
-import qs from 'qs';
+import { parse } from 'neoqs/legacy';
 
 import { ParametersMap, ParameterLocation } from '../../types';
 import { ValidationError } from '../../errors';
@@ -143,7 +143,7 @@ function deepObjectParser(
     parserContext: any
 ): any {
     if (!parserContext.qsParsed) {
-        parserContext.qsParsed = qs.parse(rawValue);
+        parserContext.qsParsed = parse(rawValue);
     }
     const qsParsed = parserContext.qsParsed;
     return qsParsed[location.name];


### PR DESCRIPTION
# Changes

Removed `qs` in favor of `neoqs`. https://github.com/PuruVJ/neoqs

# Context

As part of the ongoing [ecosystem cleanup](https://github.com/es-tooling/ecosystem-cleanup), we are migrating various projects to use lighter/faster packages.

In this case, moving from qs to neoqs.

The current dependency graph is this:

![CleanShot 2024-08-07 at 18 22 46](https://github.com/user-attachments/assets/b552644e-60a6-4d3d-8099-7880cf1d3b10)

The entire branch related to `qs` will be removed(In conjugation with body-parser moving to neoqs)
