### PR TITLE
feat: replace `pump` with built-in `stream.pipeline`

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
         "@types/lodash": "^4.14.132",
         "@types/mocha": "^10.0.0",
         "@types/node": "^18.7.23",
-        "@types/pump": "^1.0.1",
         "@types/qs": "^6.5.1",
         "@types/semver": "^7.1.0",
         "@typescript-eslint/eslint-plugin": "^7.3.1",
@@ -86,13 +85,12 @@
         "lodash": "^4.17.11",
         "openapi3-ts": "^3.1.1",
         "promise-breaker": "^6.0.0",
-        "pump": "^3.0.0",
         "qs": "^6.6.0",
         "raw-body": "^2.3.3",
         "semver": "^7.0.0"
     },
     "engines": {
-        "node": ">=6.0.0",
+        "node": ">=10.0.0",
         "npm": ">5.0.0"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import * as http from 'http';
 import * as oas3 from 'openapi3-ts';
 import pb from 'promise-breaker';
-import pump from 'pump';
+import { pipeline } from 'stream';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
 
 import { compileOptions } from './options';
@@ -179,7 +179,9 @@ export function writeHttpResult(
 
         if (httpResult.body) {
             const body = httpResult.body;
-            await pb.call((done2: pump.Callback) => pump(body, res, done2));
+            await pb.call((done2: (err: NodeJS.ErrnoException | null) => void) =>
+                pipeline(body, res, done2)
+            );
         } else {
             res.end();
         }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,16 @@
 {
     "compilerOptions": {
         /* Basic Options */
-        "target": "es2016",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-        "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-        "lib": ["es2016"],                        /* Specify library files to be included in the compilation. */
-        "allowJs": false,                         /* Allow javascript files to be compiled. */
+        "target": "es2016" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */,
+        "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */,
+        "lib": ["es2016"] /* Specify library files to be included in the compilation. */,
+        "allowJs": false /* Allow javascript files to be compiled. */,
         // "checkJs": true,                       /* Report errors in .js files. */
         // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-        "declaration": true,                      /* Generates corresponding '.d.ts' file. */
-        "sourceMap": true,                        /* Generates corresponding '.map' file. */
+        "declaration": true /* Generates corresponding '.d.ts' file. */,
+        "sourceMap": true /* Generates corresponding '.map' file. */,
         // "outFile": "./",                       /* Concatenate and emit output to single file. */
-        "outDir": "./lib",                        /* Redirect output structure to the directory. */
+        "outDir": "./lib" /* Redirect output structure to the directory. */,
         // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
         // "removeComments": true,                /* Do not emit comments to output. */
         // "noEmit": true,                        /* Do not emit outputs. */
@@ -20,34 +20,34 @@
         "stripInternal": true,
 
         /* Strict Type-Checking Options */
-        "strict": true,                           /* Enable all strict type-checking options. */
+        "strict": true /* Enable all strict type-checking options. */,
         // "strictNullChecks": true,              /* Enable strict null checks. */
         // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
         // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-        "noImplicitAny": true,                    /* Raise error on expressions and declarations with an implied 'any' type. */
-        "noImplicitThis": true,                   /* Raise error on 'this' expressions with an implied 'any' type. */
-        "alwaysStrict": true,                     /* Parse in strict mode and emit "use strict" for each source file. */
+        "noImplicitAny": true /* Raise error on expressions and declarations with an implied 'any' type. */,
+        "noImplicitThis": true /* Raise error on 'this' expressions with an implied 'any' type. */,
+        "alwaysStrict": true /* Parse in strict mode and emit "use strict" for each source file. */,
 
         /* Additional Checks */
         "forceConsistentCasingInFileNames": true,
-        "noUnusedLocals": true,                   /* Report errors on unused locals. */
-        "noUnusedParameters": true,               /* Report errors on unused parameters. */
-        "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
-        "noFallthroughCasesInSwitch": true,       /* Report errors for fallthrough cases in switch statement. */
+        "noUnusedLocals": true /* Report errors on unused locals. */,
+        "noUnusedParameters": true /* Report errors on unused parameters. */,
+        "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+        "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
 
         /* Module Resolution Options */
         // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
         // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
         // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
         // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-        "typeRoots": [                            /* List of folders to include type definitions from. */
-            "./node_modules/@types",
+        "typeRoots": [
+            /* List of folders to include type definitions from. */ "./node_modules/@types",
             "./@types"
         ],
         // "typeRoots": [],                       /* List of folders to include type definitions from. */
         // "types": [],                           /* Type declaration files to be included in compilation. */
         // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-        "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+        "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
         // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
         /* Source Map Options */
@@ -59,9 +59,8 @@
         /* Experimental Options */
         // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
         // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+        "skipLibCheck": true
     },
-    "include": [
-        "./src/**/*"
-    ],
+    "include": ["./src/**/*"],
     "compileOnSave": true
 }


### PR DESCRIPTION
Removes dependency on `pump` in favor of native `stream.pipeline`, which is supported since Node 10.

Some notes:

* I noticed that the node version matrix does not include Node 6, so I bumped engines.node to Node 10, where `stream.pipeline` is available. Both are EOL for a very long time anyway and are considered dangerous to use, so it probably should be bumped to Node 18/20.
* All tests pass
* I had to add `skipLibCheck` to tsconfig, because otherwise tsc would fail with a type issue unrelated to my change
* This PR removes 4 dependencies in total