### PR TITLE
chore: reduce dependencies from qs

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
         "@types/lodash": "^4.14.132",
         "@types/mocha": "^10.0.0",
         "@types/node": "^18.7.23",
-        "@types/qs": "^6.5.1",
         "@types/semver": "^7.1.0",
         "@typescript-eslint/eslint-plugin": "^7.3.1",
         "@typescript-eslint/parser": "^7.3.1",
@@ -83,9 +82,9 @@
         "json-ptr": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
         "lodash": "^4.17.11",
+        "neoqs": "^6.13.0",
         "openapi3-ts": "^3.1.1",
         "promise-breaker": "^6.0.0",
-        "qs": "^6.6.0",
         "raw-body": "^2.3.3",
         "semver": "^7.0.0"
     },

--- a/src/oas3/parameterParsers/index.ts
+++ b/src/oas3/parameterParsers/index.ts
@@ -1,6 +1,6 @@
 import ld from 'lodash';
 import querystring from 'querystring';
-import qs from 'qs';
+import qs from 'neoqs/legacy';
 
 import { ParametersMap, ParameterLocation } from '../../types';
 import { ValidationError } from '../../errors';


### PR DESCRIPTION
https://npmgraph.js.org/?q=qs - 18 dependencies
https://npmgraph.js.org/?q=neoqs - 0 dependencies

Used the legacy entrypoint for CJS support